### PR TITLE
Add missing Debian build dependencies

### DIFF
--- a/base/content/build-linux.content
+++ b/base/content/build-linux.content
@@ -92,7 +92,8 @@ yum install devtoolset-7-toolchain
 
 [code=bash]apt-get install build-essential libgtk2.0-dev libdbus-glib-1-dev autoconf2.13 \
 yasm libegl1-mesa-dev libasound2-dev libxt-dev zlib1g-dev libssl-dev \
-libsqlite3-dev libbz2-dev libpulse-dev zip python2.7 python-dbus
+libsqlite3-dev libbz2-dev libpulse-dev libgconf2-dev libx11-xcb-dev \
+zip python2.7 python-dbus
 [/code]
 
 [section="Arch"]


### PR DESCRIPTION
Detected by mach and they are not existed in a clear Debian
installiation.