### PR TITLE
Cleanup theme pages and add styling

### DIFF
--- a/base/content/addons-themes-complete.content
+++ b/base/content/addons-themes-complete.content
@@ -38,20 +38,29 @@
 
 [p]Note that on Windows, if the Pale Moon folder is not located in Program Files, it might be in Program Files (x86), or in the location where you installed Pale Moon. Also note that the Aero theme is used due to additional stylings for Aero; it will still work on non-Aero systems (e.g. WinXP, Linux).[dblbreak]
 
-Once these three folders have been extracted somewhere, they should be placed in a new folder called chrome. As such, your current folder structure should be:[dblbreak]
+Once these three folders have been extracted somewhere, they should be placed in a new folder called chrome. As such, your current folder structure should be:[break]
 
-chrome[break]
-|__ browser[break]
-| |__ {contents of /browser}[break]
-|__ global[break]
-| |__ {contents of /global}[break]
-|__ mozapps[break]
-. |__ {contents of /mozapps}[dblbreak]
+[ul]
+  [li]chrome[/li]
+    [ul]
+      [li]browser[/li]
+        [ul]
+          [li][contents of /browser][/li]
+        [/ul]
+      [li]global[/li]
+        [ul]
+          [li][contents of /global][/li]
+        [/ul]
+      [li]mozapps[/li]
+        [ul]
+          [li][contents of /mozapps][/li]
+        [/ul]
+    [/ul]
+[/ul]
 
 Aside from a few additional files to be added into the folder containing the chrome folder, this is the entire default theme, and will work perfectly. For these additional files, there will be a total of 3: [b]install.rdf[/b], [b]chrome.manifest[/b] and [b]icon.png[/b]. Let's start by making install.rdf. Copy the following into a text editor and save as "install.rdf", ensuring that it is not saved instead as "install.rdf.txt":[/p]
 
-[code=xml]
-<?xml version="1.0"?>
+[code=xml]<?xml version="1.0"?>
 
 <!-- This Source Code is subject to the terms of the Mozilla Public License
    - version 2.0 (the "License"). You can obtain a copy of the License at
@@ -78,18 +87,15 @@ Aside from a few additional files to be added into the folder containing the chr
       </Description>
     </em:targetApplication>
   </Description>
-</RDF>
-[/code]
+</RDF>[/code]
 
 [p]Please note that this will NOT work as-is, and is provided as template only. Please see the [link=/addons/resources/install-manifest/]Install Manifests[/link] page for more information.[dblbreak]
 
 For chrome.manifest, copy the following into a text editor and save, replacing "namehere" with the same name you used in install.rdf:[/p]
 
-[code=bash]
-skin browser namehere chrome/browser/
+[code=bash]skin browser namehere chrome/browser/
 skin mozapps namehere chrome/mozapps/
-skin global namehere chrome/global/
-[/code]
+skin global namehere chrome/global/[/code]
 
 [p]For icon.png, this is a 64x64 icon that will be used to display your theme on both about:addons and on the Pale Moon Add-ons Site.[/p]
 
@@ -222,7 +228,7 @@ skin global namehere chrome/global/
 			[td][/td]
 			[td][/td]
 			[td]prefs.css[/td]
-			[td]styling for the status bar&#39;s preferences window[/td]
+			[td]styling for the status bar's preferences window[/td]
 		[/tr]
 	[/tbody]
 [/table][dblbreak]
@@ -263,7 +269,7 @@ skin global namehere chrome/global/
 		[/tr]
 		[tr]
 			[td]aboutReader.css[/td]
-			[td]styling for reader view [b]Unused[/b][/td]
+			[td]styling for reader view[/td]
 			[td]numberbox.css[/td]
 			[td]common styling for numberboxes[/td]
 		[/tr]
@@ -487,7 +493,7 @@ skin global namehere chrome/global/
 			[th][i]/mozapps/formautofill[/i][/th]
 			[th]Description[/th]
 			[td]eula.css[/td]
-			[td]styling for providing an add-on&#39;s EULA[/td]
+			[td]styling for providing an add-on's EULA[/td]
 		[/tr]
 		[tr]
 			[td]requestAutocomplete.css[/td]
@@ -682,11 +688,9 @@ Now that we've covered where particular styles are kept, let's get on with the c
 
 With the images out of the way, make your way to /browser/browser.css and start making your theme come to life.[/p]
 
-[code=css]
-#nav-bar
+[code=css]#nav-bar
   background: red;
-}
-[/code]
+}[/code]
 
 [p]Note that most times, RGB(A)/HSL(A) values are used instead of worded names, to be able to use a precise shade.[dblbreak]
 

--- a/base/content/addons-themes-complete.content
+++ b/base/content/addons-themes-complete.content
@@ -98,7 +98,7 @@ skin global namehere chrome/global/
 
 [section="Application styles (browser)"]
 
-[table cellpadding="4" cellspacing="1"]
+[table cellpadding="4" cellspacing="1" class="wikiTable"]
 	[tbody]
 		[tr]
 			[th][i]/browser[/i][/th]
@@ -229,7 +229,7 @@ skin global namehere chrome/global/
 
 [section="Toolkit styles (global and mozapps)"]
 
-[table cellpadding="4" cellspacing="1"]
+[table cellpadding="4" cellspacing="1" class="wikiTable"]
 	[tbody]
 		[tr]
 			[th][i]/global[/i][/th]
@@ -542,7 +542,7 @@ skin global namehere chrome/global/
 
 [p][b]Developer Tools (Applies only to Pale Moon 27)[/b][/p]
 
-[table cellpadding="4" cellspacing="1"]
+[table cellpadding="4" cellspacing="1" class="wikiTable"]
 	[tbody]
 		[tr]
 			[th][i]/global/devtools[/i][/th]

--- a/base/content/addons-themes-personas.content
+++ b/base/content/addons-themes-personas.content
@@ -6,8 +6,7 @@
 
 JavaScript:[/p]
 
-[code=javascript]
-var themes = [
+[code=javascript]var themes = [
   {
     id: "example-01",
     name: "Third Planet",
@@ -35,19 +34,16 @@ function setTheme(node, theme, action) {
   var event = document.createEvent("Events");
   event.initEvent(action, true, false);
   node.dispatchEvent(event);
-}
-[/code]
+}[/code]
 
 [p]HTML:[/p]
 
-[code=html]
-<button onclick="setTheme(this, 0, INSTALL);"
+[code=html]<button onclick="setTheme(this, 0, INSTALL);"
         onmouseover="setTheme(this, 0, PREVIEW);"
         onmouseout="setTheme(this, 0, RESET_PREVIEW);">Install Third Planet Theme</button>
 <button onclick="setTheme(this, 1, INSTALL);"
         onmouseover="setTheme(this, 1, PREVIEW);"
-        onmouseout="setTheme(this, 1, RESET_PREVIEW);">Install Foxkeh Boom Theme</button>
-[/code]]
+        onmouseout="setTheme(this, 1, RESET_PREVIEW);">Install Foxkeh Boom Theme</button>[/code]
 
 [p]Note that preview by mouseover doesn't work unless your site is added to the white list of application.[/p]
 
@@ -55,8 +51,7 @@ function setTheme(node, theme, action) {
 
 [p]From within a [link=/addons/extensions/jetpack/]Bootstrap Style Extension[/url]'s bootstrap.js, you can issue code similar to the following to install and activate a lightweight theme and uninstall it on plugin deactivation.[/p]
 
-[code=javascript]
-let lightweightTheme = {
+[code=javascript]let lightweightTheme = {
     id: "example-01",
     name: "Third Planet",
     headerURL: "http://www.example.com/personas/01/header.jpg",
@@ -72,5 +67,4 @@ LightweightThemeManager.themeChanged(lightweightTheme);
 }
 function shutdown(data, reason) {
 LightweightThemeManager.forgetUsedTheme(lightweightTheme.id);
-}
-[/code]
+}[/code]

--- a/skin/palemoon/site-stylesheet.css
+++ b/skin/palemoon/site-stylesheet.css
@@ -448,4 +448,26 @@ hr {
 	color: #FFFFFF;
 }
 
+/* Table styling */
+
+.wikiTable {
+  border: 1px solid #bcbcbc;
+}
+
+.wikiTable th {
+  background-color: #ededed;
+  font-weight: bold;
+  text-align: center;
+  color: #225588;
+}
+
+.wikiTable tr {
+  padding: 4px;
+  background-color: #FFFFFF;
+}
+
+.wikiTable tr:nth-child(odd) {
+  background-color: #F0F0F0;
+}
+
 /* end of mainmenu css - change*/


### PR DESCRIPTION
Per the title. This cleans up some of the pages (typos and other random characters, plus spacing for things like the code boxes). This also provides styling for a few things, as classes.

Tables, `th` and `td` are styled here (`.tbl, .tbh, .tbd1, .tbd2`) to make them look more like tables (and specifically, using styling from the old wiki). Similarly, at least for the theme pages I've added a class `.codebox` to the code boxes and styled those so they have a border around them, separating from the other content.